### PR TITLE
bugfix: fix IP length in vxlanGwIP

### DIFF
--- a/pkg/network-engine/utils.go
+++ b/pkg/network-engine/utils.go
@@ -184,8 +184,8 @@ func vxlanGwIP(cniIP net.IP) (*net.IPNet, error) {
 	if cniIP == nil || cniIP.To4() == nil {
 		return nil, fmt.Errorf("invalid cniIP %v", cniIP)
 	}
-	gwIP := make(net.IP, len(cniIP))
-	copy(gwIP, cniIP)
+	gwIP := make(net.IP, net.IPv4len)
+	copy(gwIP, cniIP.To4())
 	gwIP[0] = vxlanGwPrefix
 	return &net.IPNet{
 		IP:   gwIP,


### PR DESCRIPTION
As `cniIP` is treated as an IPv6 address, `len(cniIP)` in the below code is 16, but `gwIP[0] = vxlanGwPrefix` is expected that the length of `gwIP` should be 4. The original code produces an invalid IP address.
https://github.com/openyurtio/raven/blob/6b14ecb13076bf2bfd61580b4313169ba5c8850e/pkg/network-engine/utils.go#L187-L189