### PR TITLE
handle DeletedFinalStateUnknown in deleteGateway

### DIFF
--- a/pkg/k8s/engine_controller.go
+++ b/pkg/k8s/engine_controller.go
@@ -303,7 +303,19 @@ func (c *EngineController) updateGateway(oldObj interface{}, newObj interface{})
 }
 
 func (c *EngineController) deleteGateway(obj interface{}) {
-	gw := obj.(*v1alpha1.Gateway)
+	gw, ok := obj.(*v1alpha1.Gateway)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("couldn't get object from tombstone %#v", obj)
+			return
+		}
+		gw, ok = tombstone.Obj.(*v1alpha1.Gateway)
+		if !ok {
+			klog.Errorf("tombstone contained object that is not a Gateway %#v", obj)
+			return
+		}
+	}
 	klog.InfoS("deleting gateway", "gateway", klog.KObj(gw))
 	c.enqueue(gw)
 }


### PR DESCRIPTION
As described in ResourceEventHandler [comments](https://github.com/kubernetes/client-go/blob/c8ffed3108783ff8ddc2010bb06c26e282ca3da7/tools/cache/controller.go#L209), it maybe will get an object of type DeletedFinalStateUnknown in deleteGateway. so should handle this case.