### PR TITLE
add helm chart

### DIFF
--- a/charts/raven-agent/.helmignore
+++ b/charts/raven-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/raven-agent/Chart.yaml
+++ b/charts/raven-agent/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: raven-agent
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.2.0"

--- a/charts/raven-agent/templates/_helpers.tpl
+++ b/charts/raven-agent/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "raven-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "raven-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "raven-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "raven-agent.labels" -}}
+helm.sh/chart: {{ include "raven-agent.chart" . }}
+{{ include "raven-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "raven-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "raven-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+raven-agent labels
+*/}}
+{{- define "raven-agent.appLabels" -}}
+app: raven-agent
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "raven-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "raven-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/raven-agent/templates/config.yaml
+++ b/charts/raven-agent/templates/config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  vpn-driver: {{ .Values.vpn.driver }}
+kind: ConfigMap
+metadata:
+  name: raven-agent-config
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+data:
+  vpn-connection-psk: {{ .Values.vpn.psk | b64enc }}
+kind: Secret
+metadata:
+  name: raven-agent-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque

--- a/charts/raven-agent/templates/daemonset.yaml
+++ b/charts/raven-agent/templates/daemonset.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: raven-agent-ds
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "raven-agent.appLabels" . | nindent 8 }}
+  template:
+    metadata:
+      labels:
+        {{- include "raven-agent.appLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: raven-agent
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- with .Values.containerEnv }}
+        env:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      hostNetwork: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable }}

--- a/charts/raven-agent/templates/rbac.yaml
+++ b/charts/raven-agent/templates/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: raven-agent-account
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: raven-agent-role
+rules:
+  - apiGroups:
+      - raven.openyurt.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: raven-agent-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: raven-agent-role
+subjects:
+  - kind: ServiceAccount
+    name: raven-agent-account
+    namespace: {{ .Release.Namespace }}

--- a/charts/raven-agent/values.yaml
+++ b/charts/raven-agent/values.yaml
@@ -1,0 +1,74 @@
+# Default values for raven-agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: openyurt/raven-agent
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "raven-agent-account"
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  privileged: true
+
+nodeSelector:
+  beta.kubernetes.io/arch: amd64
+  beta.kubernetes.io/os: linux
+
+tolerations: [{"operator": "Exists"}]
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: type
+              operator: NotIn
+              values:
+                - virtual-kubelet
+
+containerEnv:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: VPN_CONNECTION_PSK
+      valueFrom:
+        secretKeyRef:
+          key: vpn-connection-psk
+          name: raven-agent-secret
+    - name: VPN_DRIVER
+      valueFrom:
+        configMapKeyRef:
+          key: vpn-driver
+          name: raven-agent-config
+vpn:
+  driver: libreswan
+  # raven-agent requires a unique vpn psk
+  # You can generate one with the command:
+  # 'openssl rand -hex 64'
+  # Pass it to helm with '--set vpn.psk=`openssl rand -hex 64`'
+  # IMPORTANT: You should NOT use the example psk for a production deployment!
+  psk: OPENYURT-RAVEN-AGENT-VPN-PSK
+rollingUpdate:
+  maxUnavailable: 5%


### PR DESCRIPTION
Signed-off-by: hxcGit <houxc_mail@163.com>

## usage
```
helm install raven-agent charts/raven-agent --set vpn.psk=`openssl rand -hex 64`  -n kube-system
```

`Raven-agent` requires a unique vpn `psk`, we can generate one with the command: 'openssl rand -hex 64'. And pass it to helm by '--set vpn.psk=\`openssl rand -hex 64\`'.
Currently, we set `psk` to "OPENYURT-RAVEN-AGENT-VPN-PSK" in values.yaml. Users should replace it manually.

