### PR TITLE
chore: remove unused value

### DIFF
--- a/charts/raven-agent/values.yaml
+++ b/charts/raven-agent/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: openyurt/raven-agent
   pullPolicy: IfNotPresent


### PR DESCRIPTION
`raven-agent` is `Daemonset`, so `replicaCount` is unused.