### PR TITLE
fix: helm install error

### DIFF
--- a/charts/raven-agent/templates/config.yaml
+++ b/charts/raven-agent/templates/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   vpn-driver: {{ .Values.vpn.driver }}
-  forward-node-ip: {{ .Values.vpn.forward-node-ip }}
+  forward-node-ip: {{ .Values.vpn.forwardNodeIP }}
 kind: ConfigMap
 metadata:
   name: raven-agent-config

--- a/charts/raven-agent/values.yaml
+++ b/charts/raven-agent/values.yaml
@@ -67,7 +67,7 @@ containerEnv:
           name: raven-agent-config
 vpn:
   driver: libreswan
-  forward-node-ip: false
+  forwardNodeIP: false
   # raven-agent requires a unique vpn psk
   # You can generate one with the command:
   # 'openssl rand -hex 64'


### PR DESCRIPTION
helm install Error: parse error at (raven-agent/templates/config.yaml:4): bad character U+002D '-'