### PR TITLE
fix issue https://github.com/openyurtio/raven/issues/101 for helm error

### DIFF
--- a/charts/raven-agent/templates/config.yaml
+++ b/charts/raven-agent/templates/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   vpn-driver: {{ .Values.vpn.driver }}
-  forward-node-ip: {{ .Values.vpn.forwardNodeIP }}
+  forward-node-ip: {{ .Values.vpn.forwardNodeIP | quote }}
 kind: ConfigMap
 metadata:
   name: raven-agent-config


### PR DESCRIPTION
fix the configMap value format of ```raven-agent-config```.
[configMap object](https://kubernetes.io/docs/concepts/configuration/configmap/#configmap-object) says that
"The data field is designed to contain UTF-8 strings "