### PR TITLE
expose metric server address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 IMG ?= openyurt/raven-agent:latest
 VPN_DRIVER ?= libreswan
 FORWARD_NODE_IP ?= false
+METRIC_BIND_ADDR ?= ":8080"
 
 BUILDPLATFORM ?= linux/amd64
 TARGETOS ?= linux
@@ -64,7 +65,7 @@ docker-push: ## Push docker image with the agent.
 ##@ Deploy
 
 gen-deploy-yaml:
-	bash hack/gen-yaml.sh ${IMG} ${VPN_DRIVER} ${FORWARD_NODE_IP}
+	bash hack/gen-yaml.sh ${IMG} ${VPN_DRIVER} ${FORWARD_NODE_IP} ${METRIC_BIND_ADDR}
 
 deploy: gen-deploy-yaml ## Deploy agent daemon.
 	kubectl apply -f _output/yamls/raven-agent.yaml

--- a/charts/raven-agent/templates/config.yaml
+++ b/charts/raven-agent/templates/config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   vpn-driver: {{ .Values.vpn.driver }}
   forward-node-ip: {{ .Values.vpn.forwardNodeIP | quote }}
+  metric-bind-addr: {{ .Values.vpn.metricBindAddr }}
 kind: ConfigMap
 metadata:
   name: raven-agent-config

--- a/charts/raven-agent/values.yaml
+++ b/charts/raven-agent/values.yaml
@@ -74,5 +74,6 @@ vpn:
   # Pass it to helm with '--set vpn.psk=`openssl rand -hex 64`'
   # IMPORTANT: You should NOT use the example psk for a production deployment!
   psk: OPENYURT-RAVEN-AGENT-VPN-PSK
+  metricBindAddr: ":8080"
 rollingUpdate:
   maxUnavailable: 5%

--- a/charts/raven-agent/values.yaml
+++ b/charts/raven-agent/values.yaml
@@ -65,6 +65,11 @@ containerEnv:
         configMapKeyRef:
           key: forward-node-ip
           name: raven-agent-config
+    - name: METRIC_BIND_ADDR
+      valueFrom:
+        configMapKeyRef:
+          key: metric-bind-addr
+          name: raven-agent-config
 vpn:
   driver: libreswan
   forwardNodeIP: false

--- a/cmd/agent/app/config/config.go
+++ b/cmd/agent/app/config/config.go
@@ -23,12 +23,13 @@ import (
 
 // Config is the main context object for raven agent
 type Config struct {
-	NodeName      string
-	Kubeconfig    *rest.Config
-	Manager       manager.Manager
-	VPNDriver     string
-	RouteDriver   string
-	ForwardNodeIP bool
+	NodeName           string
+	Kubeconfig         *rest.Config
+	Manager            manager.Manager
+	VPNDriver          string
+	RouteDriver        string
+	ForwardNodeIP      bool
+	MetricsBindAddress string
 }
 
 type completedConfig struct {

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -21,11 +21,12 @@ import (
 
 // AgentOptions has the information that required by the raven agent
 type AgentOptions struct {
-	NodeName      string
-	Kubeconfig    string
-	VPNDriver     string
-	RouteDriver   string
-	ForwardNodeIP bool
+	NodeName           string
+	Kubeconfig         string
+	VPNDriver          string
+	RouteDriver        string
+	ForwardNodeIP      bool
+	MetricsBindAddress string
 }
 
 // Validate validates the AgentOptions
@@ -46,16 +47,18 @@ func (o *AgentOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.VPNDriver, "vpn-driver", o.VPNDriver, `The VPN driver name. (default "libreswan")`)
 	fs.StringVar(&o.RouteDriver, "route-driver", o.RouteDriver, `The Route driver name. (default "vxlan")`)
 	fs.BoolVar(&o.ForwardNodeIP, "forward-node-ip", o.ForwardNodeIP, `Forward node IP or not. (default "false")`)
+	fs.StringVar(&o.MetricsBindAddress, "metric-bind-addr", o.MetricsBindAddress, `Binding address of metrics. (default ":8080")`)
 }
 
 // Config return a raven agent config objective
 func (o *AgentOptions) Config() (*config.Config, error) {
 	var err error
 	c := &config.Config{
-		NodeName:      o.NodeName,
-		VPNDriver:     o.VPNDriver,
-		RouteDriver:   o.RouteDriver,
-		ForwardNodeIP: o.ForwardNodeIP,
+		NodeName:           o.NodeName,
+		VPNDriver:          o.VPNDriver,
+		RouteDriver:        o.RouteDriver,
+		ForwardNodeIP:      o.ForwardNodeIP,
+		MetricsBindAddress: o.MetricsBindAddress,
 	}
 	cfg, err := clientcmd.BuildConfigFromFlags("", o.Kubeconfig)
 	if err != nil {
@@ -63,7 +66,7 @@ func (o *AgentOptions) Config() (*config.Config, error) {
 	}
 	cfg = restclient.AddUserAgent(cfg, "raven-agent")
 	c.Kubeconfig = cfg
-	c.Manager, err = newMgr(cfg)
+	c.Manager, err = newMgr(cfg, c.MetricsBindAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %s", err)
 	}
@@ -76,12 +79,15 @@ func (o *AgentOptions) Config() (*config.Config, error) {
 	return c, err
 }
 
-func newMgr(cfg *restclient.Config) (manager.Manager, error) {
+func newMgr(cfg *restclient.Config, metricsBindAddress string) (manager.Manager, error) {
 	scheme := runtime.NewScheme()
 	_ = v1alpha1.AddToScheme(scheme)
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
-	})
+	opt := ctrl.Options{
+		Scheme:             scheme,
+		MetricsBindAddress: metricsBindAddress,
+	}
+	klog.Infof("[+++] opt %v", opt)
+	mgr, err := ctrl.NewManager(cfg, opt)
 	if err != nil {
 		klog.ErrorS(err, "failed to new manager for raven agent controller")
 		return nil, err

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -86,7 +86,7 @@ func newMgr(cfg *restclient.Config, metricsBindAddress string) (manager.Manager,
 		Scheme:             scheme,
 		MetricsBindAddress: metricsBindAddress,
 	}
-	klog.Infof("[+++] opt %v", opt)
+
 	mgr, err := ctrl.NewManager(cfg, opt)
 	if err != nil {
 		klog.ErrorS(err, "failed to new manager for raven agent controller")

--- a/config/raven-agent/agent/agent.yaml
+++ b/config/raven-agent/agent/agent.yaml
@@ -43,3 +43,8 @@ spec:
                 configMapKeyRef:
                   name: agent-config
                   key: forward-node-ip
+            - name: METRIC_BIND_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: agent-config
+                  key: metric-bind-addr

--- a/hack/gen-yaml.sh
+++ b/hack/gen-yaml.sh
@@ -21,6 +21,7 @@ gen_yaml() {
     local IMG=$1
     local VPN_DRIVER=$2
     local FORWARD_NODE_IP=$3
+    local METRIC_BIND_ADDR=$4
     local OUT_YAML_DIR=${YURT_ROOT}/_output/yamls
     local BUILD_YAML_DIR=${OUT_YAML_DIR}/build
     [ -f "${BUILD_YAML_DIR}" ] || mkdir -p "${BUILD_YAML_DIR}"
@@ -36,6 +37,7 @@ gen_yaml() {
     [ -f "${BUILD_YAML_DIR}"/default/psk.env ] || echo "vpn-connection-psk=$(openssl rand -hex 64)" > "${BUILD_YAML_DIR}"/default/psk.env
     [ -f "${BUILD_YAML_DIR}"/default/config.env ] || echo "vpn-driver=${VPN_DRIVER}" > "${BUILD_YAML_DIR}"/default/config.env
     echo "forward-node-ip=${FORWARD_NODE_IP}" >> "${BUILD_YAML_DIR}"/default/config.env
+    echo "metric-bind-addr=${METRIC_BIND_ADDR}" >> "${BUILD_YAML_DIR}"/default/config.env
     kustomize build "${BUILD_YAML_DIR}"/default > "${OUT_YAML_DIR}"/raven-agent.yaml
     rm -Rf "${BUILD_YAML_DIR}"
 }

--- a/raven.sh
+++ b/raven.sh
@@ -21,4 +21,4 @@ set -e -x
 [ "$(cat /proc/sys/net/ipv4/conf/all/send_redirects)" = 0 ] || echo 0 > /proc/sys/net/ipv4/conf/all/send_redirects
 
 # run raven agent
-exec agent --node-name="$NODE_NAME" --vpn-driver="$VPN_DRIVER" --forward-node-ip="$FORWARD_NODE_IP"
+exec agent --node-name="$NODE_NAME" --vpn-driver="$VPN_DRIVER" --forward-node-ip="$FORWARD_NODE_IP" --metric-bind-addr="$METRIC_BIND_ADDR"


### PR DESCRIPTION
Controller always use 8080 as default port for metric server, causing conflict when deploy two controllers in k8s.
So we need to expose the metric server address's configuration for users.

fix issue
https://github.com/openyurtio/raven/issues/104