### PR TITLE
fix boot mode for raven agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o agent cmd/agent/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o raven-agent-ds cmd/agent/main.go
 
 
 FROM alpine:3.17
@@ -30,7 +30,8 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
     && touch /run/openrc/softlevel \
     && rc-update add ipsec
 
-COPY --from=builder /workspace/agent /usr/local/bin/
+COPY --from=builder /workspace/raven-agent-ds /usr/local/bin/
 COPY pluto raven.sh /usr/local/bin/
 
 ENTRYPOINT raven.sh
+ENTRYPOINT ["/usr/local/bin/raven-agent-ds"]

--- a/raven.sh
+++ b/raven.sh
@@ -19,6 +19,3 @@ set -e -x
 
 # disable icmp redirect
 [ "$(cat /proc/sys/net/ipv4/conf/all/send_redirects)" = 0 ] || echo 0 > /proc/sys/net/ipv4/conf/all/send_redirects
-
-# run raven agent
-exec agent --node-name="$NODE_NAME" --vpn-driver="$VPN_DRIVER" --forward-node-ip="$FORWARD_NODE_IP" --metric-bind-addr="$METRIC_BIND_ADDR" --feature-gates="$FEATURE_GATES"


### PR DESCRIPTION
1. raven agent container can not get args configured in yaml if using shell (raven.sh) 
2. rename component name for  edge-hub to persist informer cache