### PR TITLE
fix the broadcast in raven0

### DIFF
--- a/pkg/networkengine/routedriver/vxlan/vxlan.go
+++ b/pkg/networkengine/routedriver/vxlan/vxlan.go
@@ -271,9 +271,10 @@ func (vx *vxlan) ensureVxlanLink(network *types.Network, vpnDriverMTUFn func() (
 			}(vpnDriverMTU, routeDriverMTU),
 			Flags: net.FlagUp,
 		},
-		VxlanId: vxlanID,
-		Age:     300,
-		Port:    vxlanPort,
+		VxlanId:  vxlanID,
+		Age:      300,
+		Port:     vxlanPort,
+		Learning: true,
 	}
 	if !vx.isGatewayRole(network) {
 		vxlanLink.Group = net.ParseIP(network.LocalEndpoint.PrivateIP)


### PR DESCRIPTION
Fixed a bug where the MAC address of the FDB table configured to the network domain on the gateway node was empty causing the return packet to be broadcast