### PR TITLE
chore: upgrade codecov-action to v4.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           sudo go test -v -short ./pkg/... ./cmd/... -coverprofile cover.out
 
       - name: Publish Unit Test Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4.5.0
         with:
           name: codecov-umbrella
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixed the docker-push action error in the CI pipeline by upgrading codecov-action from v3 to v4.5.0