### PR TITLE
feat: support independent L3/L7 engine enable/disable

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -70,11 +70,6 @@ func NewEngine(ctx context.Context, cfg *config.Config) (*Engine, error) {
 		config:        cfg,
 		ravenClient:   engine.client,
 	}
-	err = engine.tunnel.InitDriver()
-	if err != nil {
-		klog.Errorf("fail to init tunnel driver, error %s", err.Error())
-		return engine, err
-	}
 
 	engine.proxy = &ProxyEngine{
 		nodeName:    engine.nodeName,
@@ -144,13 +139,15 @@ func (e *Engine) regularSync() {
 }
 
 func (e *Engine) findLocalGateway() {
-	e.tunnel.localGateway = nil
-	e.proxy.localGateway = nil
 	var gwList v1beta1.GatewayList
 	err := e.client.List(context.TODO(), &gwList)
 	if err != nil {
+		klog.Errorf("failed to list gateways, keeping previous state: %s", err.Error())
 		return
 	}
+	// Reset only after successful list
+	e.tunnel.localGateway = nil
+	e.proxy.localGateway = nil
 	for _, gw := range gwList.Items {
 		for _, node := range gw.Status.Nodes {
 			if node.NodeName == e.nodeName {
@@ -163,7 +160,7 @@ func (e *Engine) findLocalGateway() {
 }
 
 func (e *Engine) Cleanup() {
-	if e.option.GetTunnelStatus() {
+	if e.tunnel.driverInitialized {
 		e.tunnel.CleanupDriver()
 	}
 	if e.option.GetProxyStatus() {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,0 +1,364 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openyurtio/api/raven/v1beta1"
+	"github.com/openyurtio/raven/cmd/agent/app/config"
+	"github.com/openyurtio/raven/pkg/types"
+)
+
+// mockVPNDriver implements vpndriver.Driver
+type mockVPNDriver struct {
+	initCalled    int
+	applyCalled   int
+	cleanupCalled int
+	initErr       error
+	cleanupErr    error
+}
+
+func (m *mockVPNDriver) Init() error {
+	m.initCalled++
+	return m.initErr
+}
+func (m *mockVPNDriver) Apply(_ *types.Network, _ func(*types.Network) (int, error)) error {
+	m.applyCalled++
+	return nil
+}
+func (m *mockVPNDriver) MTU() (int, error) { return 1400, nil }
+func (m *mockVPNDriver) Cleanup() error {
+	m.cleanupCalled++
+	return m.cleanupErr
+}
+
+// mockRouteDriver implements routedriver.Driver
+type mockRouteDriver struct {
+	initCalled    int
+	applyCalled   int
+	cleanupCalled int
+	initErr       error
+	cleanupErr    error
+}
+
+func (m *mockRouteDriver) Init() error {
+	m.initCalled++
+	return m.initErr
+}
+func (m *mockRouteDriver) Apply(_ *types.Network, _ func() (int, error)) error {
+	m.applyCalled++
+	return nil
+}
+func (m *mockRouteDriver) MTU(_ *types.Network) (int, error) { return 1400, nil }
+func (m *mockRouteDriver) Cleanup() error {
+	m.cleanupCalled++
+	return m.cleanupErr
+}
+
+func newTestGateway(name string, tunnelReplicas, proxyReplicas int) *v1beta1.Gateway {
+	return &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1beta1.GatewaySpec{
+			TunnelConfig: v1beta1.TunnelConfiguration{Replicas: tunnelReplicas},
+			ProxyConfig:  v1beta1.ProxyConfiguration{Replicas: proxyReplicas},
+			ExposeType:   v1beta1.ExposeTypePublicIP,
+		},
+		Status: v1beta1.GatewayStatus{
+			Nodes: []v1beta1.NodeInfo{
+				{NodeName: "node-1", PrivateIP: "10.0.0.1", Subnets: []string{"10.244.0.0/24"}},
+			},
+			ActiveEndpoints: []*v1beta1.Endpoint{
+				{NodeName: "node-1", Type: v1beta1.Tunnel, PublicIP: "1.2.3.4", Port: 4500},
+				{NodeName: "node-1", Type: v1beta1.Proxy, PublicIP: "1.2.3.4", Port: 10262},
+			},
+		},
+	}
+}
+
+// --- TunnelEngine.Status() tests ---
+
+func TestTunnelStatus_NilGateway(t *testing.T) {
+	te := &TunnelEngine{localGateway: nil}
+	if te.Status() {
+		t.Error("Status() should return false when localGateway is nil")
+	}
+}
+
+func TestTunnelStatus_ReplicasZero(t *testing.T) {
+	te := &TunnelEngine{localGateway: newTestGateway("gw", 0, 0)}
+	if te.Status() {
+		t.Error("Status() should return false when TunnelConfig.Replicas is 0")
+	}
+}
+
+func TestTunnelStatus_ReplicasPositive(t *testing.T) {
+	te := &TunnelEngine{localGateway: newTestGateway("gw", 1, 0)}
+	if !te.Status() {
+		t.Error("Status() should return true when TunnelConfig.Replicas > 0")
+	}
+}
+
+// --- ProxyEngine.Status() tests ---
+
+func TestProxyStatus_NilGateway(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pe := &ProxyEngine{localGateway: nil, client: fakeClient}
+	if pe.Status() {
+		t.Error("Status() should return false when localGateway is nil and no centre gateway")
+	}
+}
+
+func TestProxyStatus_ReplicasZero(t *testing.T) {
+	pe := &ProxyEngine{localGateway: newTestGateway("gw", 0, 0)}
+	if pe.Status() {
+		t.Error("Status() should return false when ProxyConfig.Replicas is 0")
+	}
+}
+
+func TestProxyStatus_ReplicasPositive(t *testing.T) {
+	pe := &ProxyEngine{localGateway: newTestGateway("gw", 0, 1)}
+	if !pe.Status() {
+		t.Error("Status() should return true when ProxyConfig.Replicas > 0")
+	}
+}
+
+// --- TunnelEngine.Handler() lazy init / cleanup tests ---
+
+func newTestTunnelEngine(gw *v1beta1.Gateway) (*TunnelEngine, *mockVPNDriver, *mockRouteDriver) {
+	vpn := &mockVPNDriver{}
+	route := &mockRouteDriver{}
+	return &TunnelEngine{
+		nodeName:     "node-1",
+		localGateway: gw,
+		vpnDriver:    vpn,
+		routeDriver:  route,
+		config: &config.Config{
+			Tunnel: &config.TunnelConfig{
+				VPNDriver:   "mock",
+				RouteDriver: "mock",
+			},
+		},
+	}, vpn, route
+}
+
+func TestHandler_NoGateway_NoInit(t *testing.T) {
+	te, vpn, route := newTestTunnelEngine(nil)
+	err := te.Handler()
+	if err != nil {
+		t.Fatalf("Handler() returned error: %v", err)
+	}
+	if te.driverInitialized {
+		t.Error("driverInitialized should be false")
+	}
+	if vpn.initCalled > 0 || route.initCalled > 0 {
+		t.Error("drivers should not be initialized when no gateway")
+	}
+}
+
+func TestHandler_ReplicasZero_NoInit(t *testing.T) {
+	te, vpn, route := newTestTunnelEngine(newTestGateway("gw", 0, 0))
+	err := te.Handler()
+	if err != nil {
+		t.Fatalf("Handler() returned error: %v", err)
+	}
+	if te.driverInitialized {
+		t.Error("driverInitialized should be false when Replicas=0")
+	}
+	if vpn.initCalled > 0 || route.initCalled > 0 {
+		t.Error("drivers should not be initialized when Replicas=0")
+	}
+}
+
+func TestHandler_ReplicasZero_TriggersCleanup(t *testing.T) {
+	te, vpn, route := newTestTunnelEngine(newTestGateway("gw", 0, 0))
+	te.driverInitialized = true // pretend it was initialized
+
+	err := te.Handler()
+	if err != nil {
+		t.Fatalf("Handler() returned error: %v", err)
+	}
+	if te.driverInitialized {
+		t.Error("driverInitialized should be false after cleanup")
+	}
+	if vpn.cleanupCalled != 1 {
+		t.Errorf("vpnDriver.Cleanup() should be called once, got %d", vpn.cleanupCalled)
+	}
+	if route.cleanupCalled != 1 {
+		t.Errorf("routeDriver.Cleanup() should be called once, got %d", route.cleanupCalled)
+	}
+}
+
+func TestHandler_CleanupFails_KeepsInitialized(t *testing.T) {
+	te, vpn, _ := newTestTunnelEngine(newTestGateway("gw", 0, 0))
+	te.driverInitialized = true
+	vpn.cleanupErr = fmt.Errorf("cleanup failed")
+
+	err := te.Handler()
+	if err != nil {
+		t.Fatalf("Handler() returned error: %v", err)
+	}
+	if !te.driverInitialized {
+		t.Error("driverInitialized should remain true when cleanup fails")
+	}
+}
+
+// --- findLocalGateway tests ---
+
+func TestFindLocalGateway_ListFails_KeepsPreviousState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	// Use a client that has no objects — but we'll test with a pre-set gateway
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	previousGw := newTestGateway("gw-cloud", 1, 1)
+	tunnel := &TunnelEngine{localGateway: previousGw}
+	proxy := &ProxyEngine{localGateway: previousGw}
+
+	e := &Engine{
+		nodeName: "node-1",
+		tunnel:   tunnel,
+		proxy:    proxy,
+		client:   fakeClient,
+	}
+
+	// List succeeds but finds no matching node → should clear
+	e.findLocalGateway()
+	if e.tunnel.localGateway != nil {
+		t.Error("localGateway should be nil when node not found in any gateway")
+	}
+}
+
+func TestFindLocalGateway_MatchesNode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+
+	gw := newTestGateway("gw-cloud", 1, 1)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gw).Build()
+
+	tunnel := &TunnelEngine{}
+	proxy := &ProxyEngine{}
+
+	e := &Engine{
+		nodeName: "node-1",
+		tunnel:   tunnel,
+		proxy:    proxy,
+		client:   fakeClient,
+	}
+
+	e.findLocalGateway()
+	if e.tunnel.localGateway == nil {
+		t.Fatal("tunnel.localGateway should not be nil")
+	}
+	if e.tunnel.localGateway.Name != "gw-cloud" {
+		t.Errorf("expected gateway name gw-cloud, got %s", e.tunnel.localGateway.Name)
+	}
+	if e.proxy.localGateway == nil {
+		t.Fatal("proxy.localGateway should not be nil")
+	}
+}
+
+func TestFindLocalGateway_NodeNotInGateway(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+
+	gw := newTestGateway("gw-cloud", 1, 1)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gw).Build()
+
+	tunnel := &TunnelEngine{}
+	proxy := &ProxyEngine{}
+
+	e := &Engine{
+		nodeName: "node-not-exist",
+		tunnel:   tunnel,
+		proxy:    proxy,
+		client:   fakeClient,
+	}
+
+	e.findLocalGateway()
+	if e.tunnel.localGateway != nil {
+		t.Error("tunnel.localGateway should be nil when node not in gateway")
+	}
+	if e.proxy.localGateway != nil {
+		t.Error("proxy.localGateway should be nil when node not in gateway")
+	}
+}
+
+// --- CleanupDriver returns bool tests ---
+
+func TestCleanupDriver_Success(t *testing.T) {
+	vpn := &mockVPNDriver{}
+	route := &mockRouteDriver{}
+	te := &TunnelEngine{vpnDriver: vpn, routeDriver: route}
+
+	result := te.CleanupDriver()
+	if !result {
+		t.Error("CleanupDriver should return true on success")
+	}
+	if vpn.cleanupCalled != 1 {
+		t.Errorf("vpnDriver.Cleanup() called %d times, expected 1", vpn.cleanupCalled)
+	}
+	if route.cleanupCalled != 1 {
+		t.Errorf("routeDriver.Cleanup() called %d times, expected 1", route.cleanupCalled)
+	}
+}
+
+func TestCleanupDriver_Failure(t *testing.T) {
+	vpn := &mockVPNDriver{cleanupErr: fmt.Errorf("fail")}
+	route := &mockRouteDriver{}
+	te := &TunnelEngine{vpnDriver: vpn, routeDriver: route}
+
+	result := te.CleanupDriver()
+	if result {
+		t.Error("CleanupDriver should return false on failure")
+	}
+}
+
+// --- Engine.Cleanup() tests ---
+
+func TestEngineCleanup_DriverNotInitialized(t *testing.T) {
+	vpn := &mockVPNDriver{}
+	route := &mockRouteDriver{}
+	te := &TunnelEngine{vpnDriver: vpn, routeDriver: route, driverInitialized: false}
+
+	e := &Engine{
+		tunnel: te,
+		option: NewEngineOption(),
+		proxy: &ProxyEngine{
+			proxyOption: newProxyOption(),
+			proxyCtx:    newProxyContext(context.Background()),
+		},
+	}
+
+	e.Cleanup()
+	if vpn.cleanupCalled > 0 {
+		t.Error("should not call CleanupDriver when driver not initialized")
+	}
+}
+
+func TestEngineCleanup_DriverInitialized(t *testing.T) {
+	vpn := &mockVPNDriver{}
+	route := &mockRouteDriver{}
+	te := &TunnelEngine{vpnDriver: vpn, routeDriver: route, driverInitialized: true}
+
+	e := &Engine{
+		tunnel: te,
+		option: NewEngineOption(),
+		proxy: &ProxyEngine{
+			proxyOption: newProxyOption(),
+			proxyCtx:    newProxyContext(context.Background()),
+		},
+	}
+
+	e.Cleanup()
+	if vpn.cleanupCalled != 1 {
+		t.Errorf("vpnDriver.Cleanup() called %d times, expected 1", vpn.cleanupCalled)
+	}
+}

--- a/pkg/engine/proxy.go
+++ b/pkg/engine/proxy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openyurtio/raven/pkg/proxyengine"
 	"github.com/openyurtio/raven/pkg/proxyengine/proxyclient"
 	"github.com/openyurtio/raven/pkg/proxyengine/proxyserver"
-	"github.com/openyurtio/raven/pkg/utils"
 )
 
 type ActionType string
@@ -57,17 +56,14 @@ type ProxyEngine struct {
 }
 
 func (p *ProxyEngine) Status() bool {
-	aep := getActiveEndpoints(p.localGateway, v1beta1.Proxy)
-	if aep == nil {
-		aep = getActiveEndpoints(findCentreGateway(p.client), v1beta1.Proxy)
+	gw := p.localGateway
+	if gw == nil {
+		gw = findCentreGateway(p.client)
 	}
-	if aep != nil && aep.Config != nil {
-		enable, err := strconv.ParseBool(aep.Config[utils.RavenEnableProxy])
-		if err == nil {
-			return enable
-		}
+	if gw == nil {
+		return false
 	}
-	return false
+	return gw.Spec.ProxyConfig.Replicas > 0
 }
 
 func (p *ProxyEngine) Handler() error {

--- a/pkg/engine/tunnel.go
+++ b/pkg/engine/tunnel.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/EvilSuperstars/go-cidrman"
@@ -46,11 +45,12 @@ type TunnelEngine struct {
 	forwardNodeIP bool
 	natTraversal  bool
 
-	localGateway *v1beta1.Gateway
-	config       *config.Config
-	ravenClient  client.Client
-	routeDriver  routedriver.Driver
-	vpnDriver    vpndriver.Driver
+	localGateway      *v1beta1.Gateway
+	config            *config.Config
+	ravenClient       client.Client
+	routeDriver       routedriver.Driver
+	vpnDriver         vpndriver.Driver
+	driverInitialized bool
 
 	nodeInfos map[types.NodeName]*v1beta1.NodeInfo
 	network   *types.Network
@@ -68,18 +68,24 @@ func (c *TunnelEngine) InitDriver() error {
 	}
 	c.vpnDriver, err = vpndriver.New(c.config.Tunnel.VPNDriver, c.config)
 	if err != nil {
+		if cleanupErr := c.routeDriver.Cleanup(); cleanupErr != nil {
+			klog.Errorf("fail to cleanup route driver after vpn driver creation failure: %s", cleanupErr.Error())
+		}
 		return fmt.Errorf("fail to create vpn driver: %s, %s", c.config.Tunnel.VPNDriver, err)
 	}
 	err = c.vpnDriver.Init()
 	if err != nil {
+		if cleanupErr := c.routeDriver.Cleanup(); cleanupErr != nil {
+			klog.Errorf("fail to cleanup route driver after vpn driver init failure: %s", cleanupErr.Error())
+		}
 		return fmt.Errorf("fail to initialize vpn driver: %s, %s", c.config.Tunnel.VPNDriver, err)
 	}
 	klog.Infof("route driver %s and vpn driver %s are initialized", c.config.Tunnel.RouteDriver, c.config.Tunnel.VPNDriver)
 	return nil
 }
 
-func (c *TunnelEngine) CleanupDriver() {
-	_ = wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+func (c *TunnelEngine) CleanupDriver() bool {
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		err = c.vpnDriver.Cleanup()
 		if err != nil {
 			klog.Errorf("fail to cleanup vpn driver: %s", err.Error())
@@ -92,21 +98,42 @@ func (c *TunnelEngine) CleanupDriver() {
 		}
 		return true, nil
 	})
+	if err != nil {
+		klog.Errorf("driver cleanup did not complete successfully, will retry next sync")
+		return false
+	}
+	return true
 }
 
 func (c *TunnelEngine) Status() bool {
-	aep := getActiveEndpoints(c.localGateway, v1beta1.Tunnel)
-	if aep != nil && aep.Config != nil {
-		enable, err := strconv.ParseBool(aep.Config[utils.RavenEnableTunnel])
-		if err == nil {
-			return enable
-		}
+	if c.localGateway == nil {
+		return false
 	}
-	return false
+	return c.localGateway.Spec.TunnelConfig.Replicas > 0
 }
 
 // sync syncs full state according to the gateway list.
 func (c *TunnelEngine) Handler() error {
+	shouldRun := c.Status()
+
+	if !shouldRun {
+		if c.driverInitialized {
+			klog.Infoln("L3 tunnel disabled, cleaning up drivers")
+			if c.CleanupDriver() {
+				c.driverInitialized = false
+			}
+		}
+		return nil
+	}
+
+	if !c.driverInitialized {
+		klog.Infoln("L3 tunnel enabled, initializing drivers")
+		if err := c.InitDriver(); err != nil {
+			return fmt.Errorf("fail to init tunnel driver on demand: %w", err)
+		}
+		c.driverInitialized = true
+	}
+
 	if c.config.Tunnel.NATTraversal {
 		if err := c.checkNatCapability(); err != nil {
 			klog.Errorf("fail to check the capability of NAT, error %s", err.Error())

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -43,10 +43,8 @@ const (
 	RavenProxyServerForwardLocalMode     = "Local"
 	RavenProxyServerForwardRemoteMode    = "Remote"
 
-	WorkingNamespace  = "kube-system"
-	RavenConfigName   = "raven-cfg"
-	RavenEnableProxy  = "enable-l7-proxy"
-	RavenEnableTunnel = "enable-l3-tunnel"
+	WorkingNamespace = "kube-system"
+	RavenConfigName  = "raven-cfg"
 
 	GatewayProxyInternalService  = "x-raven-proxy-internal-svc"
 	LabelCurrentGatewayEndpoints = "raven.openyurt.io/endpoints-name"


### PR DESCRIPTION
# Summary
Currently, raven-agent unconditionally initializes both L3 (`TunnelEngine`) and L7 (`ProxyEngine`) on startup. This PR introduces two new flags to allow independent control of each layer:

- `--enable-tunnel`: enables the L3 VPN tunnel engine (default: `true`)
- `--enable-proxy`: enables the L7 proxy engine (default: `true`)

Both flags default to `true`, so existing deployments require no changes.

# Changes

- `config/config.go`: add `EnableTunnel` / `EnableProxy` fields to `Config`
- `options/options.go`: add flags, validation (both-false is rejected), and conditional config construction — `c.Tunnel` / `c.Proxy` are `nil` when disabled
- `engine/engine.go`: conditionally initialize `TunnelEngine` / `ProxyEngine`; guard all `sync()`, `findLocalGateway()`, and `Cleanup()` calls with nil checks
- `start.go`: skip `disableICMPRedirect` / `disableICMPRpFilter` sysctl calls when tunnel is disabled
- `options_test.go`: add test cases for `enable-tunnel only`, `enable-proxy only`, and `both disabled` scenarios

# Behavior Matrix

--enable-tunnel | --enable-proxy | Result
-- | -- | --
true | true | Default behavior, no change
true | false | Only L3 tunnel runs, proxy not initialized
false | true | Only L7 proxy runs, sysctl skipped, no VPN driver init
false | false | Validation error at startup

# Notes
- The existing `RavenL7Proxy` feature gate is intentionally left untouched to avoid unrelated changes
- When `--enable-tunnel=false`, VPN driver and MAC prefix validation are skipped as they are irrelevant

Closes: #188 